### PR TITLE
Move to pdo

### DIFF
--- a/Samples/DomainLixo/Modelo.php
+++ b/Samples/DomainLixo/Modelo.php
@@ -93,15 +93,36 @@ class Lixao
     }
 }
 
+class LixoRepository
+{
+    private $pdo;
+    public function __construct($pdo)
+    {
+        $this->pdo = $pdo;
+    }
+    public function find($id)
+    {
+        $r = $this->pdo->query("select * from sistemaDeLixo where id={$id}", \PDO::FETCH_ASSOC);
+      $dados = $r->fetchAll();
+      return $dados[0];
+    }
+    public function save(array $data)
+    {
+        $r = $this->pdo->exec("update sistemaDeLixo set localDeRetirada={$data['localDeRetirada']}, Lixao={$data['Lixao']} where id={$data['id']}");
+        
+    }
+}
 class ServicoDeLixo
 {
     private $dataStructure;
     private $localDeRetirada;
     private $lixao;
+    private $repository;
     public function __construct($dataStructure)
     {
         $this->dataStructure = $dataStructure;
-        $initialState = $this->dataStructure->get()['sistemaDeLixo'][1];
+        $this->repository = new LixoRepository($dataStructure);
+        $initialState = $this->repository->find(1);
         $this->localDeRetirada = new LocalDeRetirada($initialState['localDeRetirada']);
         $this->lixao           = new Lixao($initialState['Lixao']);
     }
@@ -131,9 +152,16 @@ class ServicoDeLixo
     }
     private function persist()
     {
-        $dadosAtuais = $this->dataStructure->get(['sistemaDeLixo'=>[1]]);
-        $quantoTemlocal = $dadosAtuais['sistemaDeLixo'][1]['localDeRetirada'];
-        $quantoTemLixao = $dadosAtuais['sistemaDeLixo'][1]['Lixao'];
+        $dadosAtuais = $this->repository->find(1);
+        $quantoTemlocal = $dadosAtuais['localDeRetirada'];
+        $quantoTemLixao = $dadosAtuais['Lixao'];
+        $this->repository->save(
+        [
+            'id'=>1,
+            'localDeRetirada'=>$this->localDeRetirada->quantoLixoTem(), 
+            'Lixao'=>$this->lixao->quantoLixoTem()
+        ]);
+/*
         $this->dataStructure->add(
         [
             'sistemaDeLixo'=>
@@ -145,6 +173,7 @@ class ServicoDeLixo
             ]
         ]
         );
+*/
         
     }
     public function getInfo()

--- a/Samples/DomainLixo/tests/Cenarios/run.php
+++ b/Samples/DomainLixo/tests/Cenarios/run.php
@@ -9,6 +9,7 @@ use \Lixo\Lixeiro;
 use \Lixo\Morador;
 use \Lixo\LocalDeRetirada;
 use \Lixo\ServicoDeLixo;
+use \Lixo\LixoRepository;
 
 use Iannsp\Scenery\Scenery;
 use Iannsp\Scenery\Data;
@@ -16,41 +17,50 @@ use Iannsp\Scenery\RunStrategy\Strategy;
 use Iannsp\Scenery\RunStrategy\Factory;
 
 use Assert\Assertion;
-$dados = new Data([
-    'sistemaDeLixo'=>
-        [
-            ['key'=>1,['localDeRetirada'=>0, 'Lixao'=>0]]
-        ]
-    ]
-    );
 
-    $scenery = New Scenery($dados);
+$dsn ='sqlite:/tmp/sceneryTest.sq3';
+$pdo = new \PDO( $dsn);
+$pdo->exec('
+drop table sistemaDeLixo; 
+create table sistemaDeLixo(id integer primary key, localDeRetirada integer, Lixao integer)');
+$pdo->exec("insert into sistemaDeLixo (localDeRetirada, Lixao) values (0,0)");
+$pdo->newFromDsn = new \PDO( $dsn);
+
+    $scenery = New Scenery($pdo);
     $scenery->action('Produzir Lixo', function($state){
         $umDiaQualquer = new ServicoDeLixo($state['new']);    
         $umDiaQualquer->produzirLixo();
     }, function($state){
-        $newStatelocalDeRetirada = $state['new']->get()['sistemaDeLixo'][1]['localDeRetirada'];
-        $oldStatelocalDeRetirada = $state['old']->get()['sistemaDeLixo'][1]['localDeRetirada'];
-        Assertion::true(($newStatelocalDeRetirada >= $oldStatelocalDeRetirada),"Coleta Esta mais rapida que geração" );
+        $repoNew = new LixoRepository($state['new']);
+        $repoOld = new LixoRepository($state['old']);
+        $newStatelocalDeRetirada = $repoNew->find(1);
+        $oldStatelocalDeRetirada = $repoOld->find(1);        Assertion::true(($newStatelocalDeRetirada >= $oldStatelocalDeRetirada),"Coleta Esta mais rapida que geração" );
     });
 
     $scenery->action('Coletar Lixo', function($state){
         $umDiaQualquer = new ServicoDeLixo($state['new']);    
         $umDiaQualquer->coletarLixo();
     }, function($state){
+        $repositoryNew = new LixoRepository($state['new']);
+        $repositoryOld = new LixoRepository($state['old']);
+        var_dump($repositoryOld->find(1));
+/*
         $newStateLixao = $state['new']->get()['sistemaDeLixo'][1]['Lixao'];
         $oldStateLixao = $state['old']->get()['sistemaDeLixo'][1]['Lixao'];
         Assertion::true(($newStateLixao >= $oldStateLixao),"Recolhendo Pouco Lixo" );
+*/
     });
 
     $rodarAte = new \Datetime();
-    $rodarAte->add(new \DateInterval("P0YT3M0S"));
+    $rodarAte->add(new \DateInterval("P0YT0M6S"));
     $runnerStrategy = Factory::get(Strategy::RUN_UNTILDATE,$scenery);
-    $result = $runnerStrategy->run(['until'=>$rodarAte,'by'=>1]);
+    $result = $runnerStrategy->run(['until'=>$rodarAte,'by'=>1,'loud'=>true]);
     $info = ["localDeRetirada"=>0,"Lixao"=>0];
     foreach ($result as $r){
+/*
         echo "No Local de Retirada tem {$info['localDeRetirada']} Sacos de Lixo e no Lixao {$info['Lixao']}.\n";
         $info = $r['data']->get(['sistemaDeLixo'=>[1]])['sistemaDeLixo'][1];
 //        var_dump ($info);
+*/
     }
     ?>

--- a/src/Iannsp/Scenery/RunStrategy/ByCycleNumber.php
+++ b/src/Iannsp/Scenery/RunStrategy/ByCycleNumber.php
@@ -12,12 +12,13 @@ class ByCycleNumber implements Strategy{
     public function run($rule)
     {
         $result = [];
-        if (!is_int($rule))
+        //['cycles'=>1, 'loud'=>false]
+        if (!is_int($rule['cycles']))
             throw new \Exception("rule for run ByCycleNumber Strategy is int totalOfCycles");
-        $totalOfCyCles = $rule;
+        $totalOfCyCles = $rule['cycles'];
         $idOfCycle = 0;
         
-        while ($idOfCycle < $rule){
+        while ($idOfCycle < $rule['cycles']){
             $result[$idOfCycle] = 
                 $this->scenery->run($idOfCycle);
             $idOfCycle++;

--- a/src/Iannsp/Scenery/RunStrategy/ByUntilDate.php
+++ b/src/Iannsp/Scenery/RunStrategy/ByUntilDate.php
@@ -21,11 +21,14 @@ class ByUntilDate implements Strategy{
         
         $diff = (int)$untilDate->format('U') - (int)$now->format("U");
         while($diff>0){
-            $result[$idOfCycle] = $this->scenery->run($idOfCycle);
+            $result[$idOfCycle] = $this->scenery->run($idOfCycle, $rule['loud']);
             $idOfCycle++;
             usleep(1000000 * $rule['by']);
-            echo "cycle of {$diff}seconds\n";
-            flush();
+            if($rule['loud']){
+                ob_start();
+                echo "cycle of {$diff}seconds\n";
+                ob_end_flush();
+            }
             $now = new \DateTime();
             $diff = (int)$untilDate->format('U') - (int)$now->format("U");
         }

--- a/src/Iannsp/Scenery/Scenery.php
+++ b/src/Iannsp/Scenery/Scenery.php
@@ -4,7 +4,7 @@ use Assert\Assertion;
 class Scenery{
     private $data;
     private $actions = [];
-    public function __construct(Data $initData)
+    public function __construct(\PDO $initData)
     {
         $this->data = $initData;
     }
@@ -21,18 +21,22 @@ class Scenery{
         ];
     }
     
-    public function run($cycleId)
+    public function run($cycleId, $loud=false)
     {
         $result = [];
         $state['cycle']= $cycleId;
         $state['new'] = $this->data;
+        $state['old'] = $this->data->newFromDsn;
+        $state['loud'] = $loud;
         foreach($this->actions as $actionItem){
-            $state['old'] = clone $this->data;
+            $state['new']->exec('Begin;');//beginTransaction();
             $actionItem['action']($state);
             $actionItem['expectedDomain']($state);
             if (!is_null($actionItem['expectedInfraStructure']))
                 $actionItem['expectedInfraStructure']($state);
+            $state['new']->exec('Commit');
         }
+//        return ['data'=>(clone $this->data)]; Tem que virar um dump dos dados
         return ['data'=>(clone $this->data)];
     }
 }

--- a/tests/Iannsp/Scenery/RunStrategy/FactoryTest.php
+++ b/tests/Iannsp/Scenery/RunStrategy/FactoryTest.php
@@ -6,9 +6,22 @@ use Assert\Assertion;
 
 class FactoryTest extends \PHPUnit_Framework_TestCase
 {
+    private $pdo;
+    public function setUp()
+    {
+        $dsn ='sqlite:/tmp/sceneryTest.sq3';
+        $this->pdo = new \PDO( $dsn);
+        $this->pdo->exec('
+        drop table person; 
+        create table person(id integer primary key, name CHARACTER(100), email CHARACTER(100))');
+        $this->pdo->exec("insert into person (name, email) values ('Ivo','iannsp@gmail.com')");
+        $this->pdo->newFromDsn = new \PDO( $dsn);
+    }
+    
+
     public function test_get_instance_of_Strategy_ByCycleNumber()
     {
-        $scenery = new Scenery(new Data());
+        $scenery = new Scenery($this->pdo);
         $runnerStrategy = factory::get(Strategy::RUN_BY_CYCLE_NUMBER,$scenery);
         $this->assertInstanceOf(
             "\\Iannsp\\Scenery\\RunStrategy\\ByCycleNumber", 
@@ -21,24 +34,24 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 */
     public function test_get_instance_of_Strategy_Invalid()
     {
-        $scenery = new Scenery(new Data());
+        $scenery = new Scenery($this->pdo);
         $runnerStrategy = factory::get('Strategy_Invalid',$scenery);
     }
     
     public function test_run_Strategy_ByCycleNumber()
     {
-        $scenery = new Scenery(new Data());
+        $scenery = new Scenery($this->pdo);
         $runnerStrategy = factory::get(Strategy::RUN_BY_CYCLE_NUMBER,$scenery);
         $this->assertInstanceOf(
             "\\Iannsp\\Scenery\\RunStrategy\\ByCycleNumber", 
             $runnerStrategy);
-        $result = $runnerStrategy->run(1);
+            $result = $runnerStrategy->run(['cycles'=>1, 'loud'=>false]);
         $this->assertCount(1, $result);
     }
 
     public function test_run_Strategy_ByUntilDate()
     {
-        $scenery = new Scenery(new Data());
+        $scenery = new Scenery($this->pdo);
         $runnerStrategy = factory::get(Strategy::RUN_UNTILDATE,$scenery);
         $this->assertInstanceOf(
             "\\Iannsp\\Scenery\\RunStrategy\\ByUntilDate", 
@@ -47,7 +60,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             $rodarAte = new \Datetime();
             $rodarAte->add(new \DateInterval("P0YT0M2S"));
 
-        $result = $runnerStrategy->run(['until'=>$rodarAte,'by'=>1]);
+        $result = $runnerStrategy->run(['until'=>$rodarAte,'by'=>1,'loud'=>false]);
         $this->assertCount(2, $result);
     }
 }

--- a/tests/Iannsp/Scenery/SceneryTest.php
+++ b/tests/Iannsp/Scenery/SceneryTest.php
@@ -10,19 +10,39 @@ class PessoaSample
     {
         $this->data = $data;
     }
-    public function save(Data $repositorio)
+    public function save(\Pdo $pdo)
     {
-        $repositorio->add(
-        [
-            'person'=>[
-                ["key"=>$this->data['id'],$this->data]
-                    ]
-        ]);
+        $result = $pdo->query("select count(id) from person where id={$this->data['id']}", \PDO::FETCH_ASSOC);
+        $exist = $result->fetchAll()[0];
+        if($exist['count(id)']==1){
+            $result = $pdo->exec("update person set name='{$this->data['name']}', email='{$this->data['email']}' where id={$this->data['id']}");
+        } else{
+            $pdo->exec("insert into person (name, email) values ('{$this->data['name']}','{$this->data['email']}')");
+        }
+    }
+    public static function find($pdo, $id)
+    {
+        $r = $pdo->query("select * from person where id={$id}", \PDO::FETCH_ASSOC);
+      $pessoaData = $r->fetchAll()[0];
+      return $pessoaData;
     }
 }
 
 class SceneryTest extends \PHPUnit_Framework_TestCase
 {
+    private $pdo;
+    public function setUp()
+    {
+        $dsn ='sqlite:/tmp/sceneryTest.sq3';
+        $this->pdo = new \PDO( $dsn);
+        $this->pdo->exec('
+        drop table person; 
+        create table person(id integer primary key, name CHARACTER(100), email CHARACTER(100))');
+        $this->pdo->exec("insert into person (name, email) values ('Ivo','iannsp@gmail.com')");
+        $this->pdo->newFromDsn = new \PDO( $dsn);
+    }
+    
+    
     public function assertPreConditions()
     {
         $this->assertTrue(class_exists('Iannsp\Scenery\Scenery'));
@@ -30,107 +50,87 @@ class SceneryTest extends \PHPUnit_Framework_TestCase
     
     public function test_init_data_model()
     {
-        $scenery = new Scenery(new Data());
+        $scenery = new Scenery($this->pdo);
     }
     
     public function test_add_action()
     {
         assert_options(ASSERT_ACTIVE, 1);
-        $data = new Data();
-        $data->add([
-            'person'=>[
-                ["key"=>'1',['id'=>1,"name"=>'Ivo','email'=>'iannsp@gmail.com']]
-                ]
-        ]);
-        $scenery = new Scenery($data);
-        $scenery->action('Altera Uma Pessoa', function()use ($data){
-           $pessoaData = $data->get(['person'=>[1]])['person'][1];
+        $scenery = new Scenery($this->pdo);
+        $pdo = $this->pdo;
+        $scenery->action('Altera Uma Pessoa', function()use ($pdo){
+             $r = $pdo->query("select * from person where id=1", \PDO::FETCH_ASSOC);
+           $pessoaData = $r->fetchAll()[0];
            $pessoa = new PessoaSample($pessoaData);
-           $pessoa->data['nome'] = "Ivo Nascimento";
-           $pessoa->save($data);
-        }, function() use($data){
-            $pessoaData = $data->get(['person'=>[1]])['person'][1];
+           $pessoa->data['name'] = "Ivo Nascimento";
+           $pessoa->save($pdo);
+        }, function() use($pdo){
+            $r = $pdo->query("select * from person where id=1", \PDO::FETCH_ASSOC);
+          $pessoaData = $r->fetchAll()[0];
             $pessoa = new PessoaSample($pessoaData);
-            assert('$pessoa->data[\'nome\']=="Ivo Nascimento"',"ahhhhhh");
+            assert('$pessoa->data[\'name\']=="Ivo Nascimento"',"ahhhhhh");
         }
     );
-        
+    
     }
     
     public function test_run_actions()
     {
         assert_options(ASSERT_ACTIVE, 1);
-        $data = new Data();
-        $data->add([
-            'person'=>[
-                ["key"=>'1',['id'=>1,"name"=>'Ivo','email'=>'iannsp@gmail.com']]
-                ]
-        ]);
-        $scenery = new Scenery($data);
-        $scenery->action('Altera Uma Pessoa', function()use ($data){
-           $pessoaData = $data->get(['person'=>[1]])['person'][1];
+        $scenery = new Scenery($this->pdo);
+        $pdo = $this->pdo;
+        $scenery->action('Altera Uma Pessoa', function()use ($pdo){
+           $pessoaData = PessoaSample:: find($pdo, 1);
            $pessoa = new PessoaSample($pessoaData);
-           $pessoa->data['nome'] = "Ivo Nascimento";
-           $pessoa->save($data);
-        }, function() use($data){
-            $pessoaData = $data->get(['person'=>[1]])['person'][1];
+           $pessoa->data['name'] = "Ivo Nascimento";
+           $pessoa->save($pdo);
+        }, function($state) use($pdo){
+            $pessoaData = PessoaSample:: find($pdo, 1);
             $pessoa = new PessoaSample($pessoaData);
-            assert('$pessoa->data[\'nome\']=="Ivo Nascimento"',"ahhhhhh");
+            assert('$pessoa->data[\'name\']=="Ivo Nascimento"',"ahhhhhh");
         }
     );
-    $result = $scenery->run(1);
+    $runnerStrategy = Factory::get(Strategy::RUN_BY_CYCLE_NUMBER,$scenery);
+    $result = $runnerStrategy->run(['cycles'=>1, 'loud'=>false]);
     $this->assertTrue(is_array($result));
     $this->assertCount(1, $result);
-    $this->assertArrayHasKey('data', $result);
+    $this->assertArrayHasKey('data', $result[0]);
     }
     
     public function test_run_actions_lot_of_cycle()
     {
-        assert_options(ASSERT_ACTIVE, 1);
-        $data = new Data();
-        $data->add([
-            'person'=>[
-                ["key"=>'1',['id'=>1,"name"=>'Ivo','email'=>'iannsp@gmail.com']]
-                ]
-        ]);
-        $scenery = new Scenery($data);
+        $scenery = new Scenery($this->pdo);
         $scenery->action('Altera Uma Pessoa', function($state){
-           $pessoaData = $state['new']->get(['person'=>[1]])['person'][1];
+           $pessoaData = PessoaSample:: find($state['new'], 1);
            $pessoa = new PessoaSample($pessoaData);
            $pessoa->data['name'] = $pessoa->data['name']."X";
            $pessoa->save($state['new']);
         }, function($state){
-            $newPessoaData = $state['new']->get(['person'=>[1]])['person'][1];
-            $oldPessoaData = $state['old']->get(['person'=>[1]])['person'][1];
+            $newPessoaData = PessoaSample:: find($state['new'], 1);
+            $oldPessoaData = PessoaSample:: find($state['old'], 1);
           assert('$oldPessoaData[\'name\']."X"==$newPessoaData["name"]',"Nao esta seguindo a regra");
         }
     );
     $runnerStrategy = Factory::get(Strategy::RUN_BY_CYCLE_NUMBER,$scenery);
-    $result = $runnerStrategy->run(10);
+    $result = $runnerStrategy->run(['cycles'=>10, 'loud'=>false]);
     $this->assertTrue(is_array($result));
     $this->assertCount(10, $result);
     $this->assertArrayHasKey('data', $result[0]);
-    $final = $result[9]['data']->get(['person'=>[1]])['person'][1];
+    $final = PessoaSample:: find($this->pdo, 1);
     $this->assertEquals($final['name'], "IvoXXXXXXXXXX");
     }
     
     public function test_run_cycle_byDateTimeLimit()
     {
-        $data = new Data();
-        $data->add([
-            'person'=>[
-                ["key"=>'1',['id'=>1,"name"=>'Ivo','email'=>'iannsp@gmail.com']]
-                ]
-        ]);
-        $scenery = new Scenery($data);
+        $scenery = new Scenery($this->pdo);
         $scenery->action('Altera Uma Pessoa', function($state){
-           $pessoaData = $state['new']->get(['person'=>[1]])['person'][1];
+           $pessoaData = PessoaSample:: find($state['old'], 1);
            $pessoa = new PessoaSample($pessoaData);
            $pessoa->data['name'] = $pessoa->data['name']."X";
            $pessoa->save($state['new']);
         }, function($state){
-            $newPessoaData = $state['new']->get(['person'=>[1]])['person'][1];
-            $oldPessoaData = $state['old']->get(['person'=>[1]])['person'][1];
+            $newPessoaData = PessoaSample:: find($state['new'], 1);
+            $oldPessoaData = PessoaSample:: find($state['old'], 1);
             \Assert\that($newPessoaData['name'])->contains('IvoX');
         }
     );
@@ -138,11 +138,11 @@ class SceneryTest extends \PHPUnit_Framework_TestCase
     $rodarAte = new \Datetime();
     $rodarAte->add(new \DateInterval("P0YT0M4S"));
     $runnerStrategy = factory::get(Strategy::RUN_UNTILDATE,$scenery);
-    $result = $runnerStrategy->run(['until'=>$rodarAte,'by'=>1]);
+    $result = $runnerStrategy->run(['until'=>$rodarAte,'by'=>1,'loud'=>true]);
     $this->assertTrue(is_array($result));
     $this->assertCount(4, $result);
     $this->assertArrayHasKey('data', $result[0]);
-    $final = $result[3]['data']->get(['person'=>[1]])['person'][1];
+    $final = PessoaSample:: find($this->pdo, 1);
     $this->assertEquals($final['name'], "IvoXXXX");
     }
 }


### PR DESCRIPTION
This PR move from Data Struncture to pdo.
I use pdo->beginTransaction to create New and Old states of same resousrce and a hack into PDO class to have other instance attached.

Like here
```PHP
$dsn ='sqlite:/tmp/sceneryTest.sq3';
$pdo = new \PDO( $dsn);
$pdo->exec('
drop table sistemaDeLixo; 
create table sistemaDeLixo(id integer primary key, localDeRetirada integer, Lixao integer)');
$pdo->exec("insert into sistemaDeLixo (localDeRetirada, Lixao) values (0,0)");
$pdo->newFromDsn = new \PDO( $dsn);
```